### PR TITLE
Update roots-records and client-templates deps, fix configuration for…

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -16,7 +16,10 @@ module.exports =
     js_pipeline(files: 'assets/js/*.coffee'),
     css_pipeline(files: 'assets/css/*.styl'),
     templates(base: 'views/templates'),
-    records(staff: { url: api_url, path: 'data' }),
+    records(staff:
+      url: api_url,
+      hook: (res) -> res.data,
+    ),
     config(api_url: api_url, static_items: 10)
   ]
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "dependencies": {
     "autoprefixer-stylus": "0.5.x",
     "axis": "0.3.x",
-    "client-templates": "0.1.x",
+    "client-templates": "^0.2.0",
     "coffee-script": "1.8.x",
     "css-pipeline": "0.1.x",
     "jade": "1.x",
     "js-pipeline": "0.1.x",
     "marked": "0.3.x",
     "roots-config": "0.0.2",
-    "roots-records": "0.1.x",
+    "roots-records": "^0.5.1",
     "rupture": "0.6.x",
     "stylus": "0.49.x"
   }


### PR DESCRIPTION
… roots-records v0.5.x.

I was following along the "[Hybrid Static Sites with Roots](https://www.youtube.com/watch?v=cGzkohoTUHc)" video, doing my work in a fresh roots project (created with `roots new`).

There I installed (amongst others) the latest version (0.5.1) of [roots-records](https://github.com/carrot/roots-records), which conflicted with the configuration targeted at roots-records 0.1.0 shown in the video.

This pull request updates the roots-records and client-templates dependencies and fixes the roots-records configuration.
